### PR TITLE
VSC Tasks should compile for wasm32-unknown-unknown to ensure compatability

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -7,14 +7,14 @@
         {
             "label": "[Framework] Build (Debug)",
             "type": "shell",
-            "command": "cargo build --workspace --exclude engine_app --exclude engine_web",
+            "command": "cargo build --workspace --exclude engine_app --exclude engine_web --target wasm32-unknown-unknown",
             "group": "build",
             "options": {"cwd": "Framework/"}
         },
         {
             "label": "[Framework] Build (Release)",
             "type": "shell",
-            "command": "cargo build --workspace --exclude engine_app --exclude engine_web --release",
+            "command": "cargo build --workspace --exclude engine_app --exclude engine_web --target wasm32-unknown-unknown --release",
             "group": "build",
             "options": {"cwd": "Framework/"}
         },


### PR DESCRIPTION
Fixes #51