### PR TITLE
GitHub Actions framework tests are useless at the moment as .wasm files can't be executed for testing

### DIFF
--- a/.github/workflows/multiplatform_build.yml
+++ b/.github/workflows/multiplatform_build.yml
@@ -33,11 +33,14 @@ jobs:
       - name: Install Rust
         run: curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain stable --profile minimal -y
 
+      - name: Install Wasm-Pack
+        run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+
       - name: Build
         run: cargo build --workspace --exclude engine_app --exclude engine_web --release --verbose
 
       - name: Test
-        run: cargo test --no-fail-fast --workspace --exclude engine_app --exclude engine_web --verbose
+        run: find crates/ -mindepth 1 -maxdepth 1 -type d -not -name engine_web -or -not -name engine_app -exec wasm-pack test --node {} \;
 
       - name: Cache Save
         uses: actions/cache/save@v4


### PR DESCRIPTION
Fixes #55