### PR TITLE
Update main.yml

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,6 +33,9 @@ jobs:
           rustup default stable
           rustup update
 
+      - name: 🔁 Update mirrors
+        run: sudo apt-get update
+
       - name: 🛠️ Install dependencies
         run: sudo apt-get install -y libudev-dev
 
@@ -59,6 +62,9 @@ jobs:
         run: |
           rustup default stable
           rustup update
+
+      - name: 🔁 Update mirrors
+        run: sudo apt-get update
 
       - name: 🛠️ Install dependencies
         run: sudo apt-get install -y libudev-dev
@@ -90,6 +96,9 @@ jobs:
           rustup default stable
           rustup update
 
+      - name: 🔁 Update mirrors
+        run: sudo apt-get update
+
       - name: 🛠️ Install dependencies
         run: sudo apt-get install -y libudev-dev
 
@@ -116,6 +125,10 @@ jobs:
         run: |
           rustup default stable
           rustup update
+
+      - name: 🔁 Update mirrors (Linux)
+        if: ${{ startsWith(matrix.os, 'ubuntu') }}
+        run: sudo apt-get update
 
       - name: 🛠️ Install LibUDev (Linux)
         # Note: LibUDev is for GilRs (controller inputs)


### PR DESCRIPTION
APT mirrors are only updated on non-amd64 architectures, causing potential cache misses and missing references in the pipeline.